### PR TITLE
Allow args without a value

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -205,7 +205,6 @@ class DockerfileGenerator < Rails::Generators::Base
       @@vars.delete phase if @@vars[phase].empty?
 
       @@args[phase].merge! options["arg-#{phase}"]
-      @@args[phase].delete_if { |key, value| value.blank? }
       @@args.delete phase if @@args[phase].empty?
     end
 

--- a/test/results/arg/Dockerfile
+++ b/test/results/arg/Dockerfile
@@ -1,0 +1,69 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=xxx
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_WITHOUT="development:test" \
+    BUNDLE_DEPLOYMENT="1"
+
+# Update gems and bundler
+RUN gem update --system --no-document && \
+    gem install -N bundler
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential pkg-config
+
+# Build arguments
+ARG FOO="BAR" \
+    COMMIT
+
+# Install application gems
+COPY --link Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ $BUNDLE_PATH/ruby/*/cache $BUNDLE_PATH/ruby/*/bundler/gems/*/.git
+
+# Copy application code
+COPY --link . .
+
+# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+RUN SECRET_KEY_BASE=DUMMY ./bin/rails assets:precompile
+
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for deployment
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y libsqlite3-0 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /rails /rails
+
+# Run and own only the runtime files as a non-root user for security
+RUN useradd rails --home /rails --shell /bin/bash && \
+    chown -R rails:rails db log tmp
+USER rails:rails
+
+# Deployment options
+ENV RAILS_LOG_TO_STDOUT="1" \
+    RAILS_SERVE_STATIC_FILES="true"
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/test/test_arg.rb
+++ b/test/test_arg.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class TestArg < TestBase
+  @rails_options = "--minimal"
+  @generate_options = "--arg-build=FOO:BAR COMMIT"
+
+  def test_env
+    check_dockerfile
+  end
+end


### PR DESCRIPTION
**This is a WIP. I'd appreciate some help with it, as well as confirmation it's worth doing.**

In a Dockerfile, the `ENV` keyword requires a name and value. But `ARG` just requires a name; a default value is optional. There's some examples [here](https://docs.docker.com/engine/reference/builder/#using-arg-variables), and another one [here](https://community.fly.io/t/git-commit-sha-of-current-build/1870/2) which is what led me to this.

So this PR allows you to provide args without a default value.