### PR TITLE
Replace typo bunde with bundle at sidekiq command

### DIFF
--- a/lib/generators/templates/docker-compose.yml.erb
+++ b/lib/generators/templates/docker-compose.yml.erb
@@ -82,7 +82,7 @@ services:
 
   sidekiq:
     build: .
-    command: bunde exec sidekiq
+    command: bundle exec sidekiq
     environment:
       - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
       - REDIS_URL=redis://redis-db:6379

--- a/test/results/sidekiq/docker-compose.yml
+++ b/test/results/sidekiq/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   sidekiq:
     build: .
-    command: bunde exec sidekiq
+    command: bundle exec sidekiq
     environment:
       - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
       - REDIS_URL=redis://redis-db:6379


### PR DESCRIPTION
I've upgraded to v1.4.1, regenerated files and found sidekiq command was misspelled. I've manually tweaked it in my project and thought it'd be great to see it fixed at upstream.

Last but not least thanks for providing us with this awesome project and also maintaining it 😄 
