### PR TITLE
Detect usage of trilogy and adapt Dockerfile & docker-compose accordingly

### DIFF
--- a/lib/dockerfile-rails/scanner.rb
+++ b/lib/dockerfile-rails/scanner.rb
@@ -44,7 +44,7 @@ module DockerfileRails
         @sqlite3 = true
       elsif database == "postgresql"
         @postgresql = true
-      elsif (database == "mysql") || (database == "mysql2")
+      elsif (database == "mysql") || (database == "mysql2") || (database == "trilogy")
         @mysql = true
       elsif database == "sqlserver"
         @sqlserver = true
@@ -52,7 +52,7 @@ module DockerfileRails
 
       @sqlite3 = true if @gemfile.include? "sqlite3"
       @postgresql = true if @gemfile.include? "pg"
-      @mysql = true if @gemfile.include? "mysql2"
+      @mysql = true if @gemfile.include?("mysql2") || using_trilogy?
 
       ### node modules ###
 
@@ -80,6 +80,10 @@ module DockerfileRails
       end
 
       @redis = @redis_cable || @redis_cache
+    end
+
+    def using_trilogy?
+      @gemfile.include?("trilogy") || @gemfile.include?("activerecord-trilogy-adapter")
     end
   end
 end

--- a/lib/generators/templates/docker-compose.yml.erb
+++ b/lib/generators/templates/docker-compose.yml.erb
@@ -21,7 +21,11 @@ services:
 <% if deploy_database == 'postgresql' -%>
       - DATABASE_URL=postgres://root:password@postgres-db/
 <% elsif deploy_database == 'mysql' -%>
+<% if using_trilogy? -%>
+      - DATABASE_URL=trilogy://root:password@mysql-db/
+<% else -%>
       - DATABASE_URL=mysql2://root:password@mysql-db/
+<% end -%>
 <% end -%>
 <% if deploy_database == 'sqlite3' -%>
     volumes:
@@ -89,7 +93,11 @@ services:
 <% if deploy_database == 'postgresql' -%>
       - DATABASE_URL=postgres://root:password@postgres-db/
 <% elsif deploy_database == 'mysql' -%>
+<% if using_trilogy? -%>
+      - DATABASE_URL=trilogy://root:password@mysql-db/
+<% else -%>
       - DATABASE_URL=mysql2://root:password@mysql-db/
+<% end -%>
 <% end -%>
     depends_on:
       redis-db:

--- a/test/results/trilogy/Dockerfile
+++ b/test/results/trilogy/Dockerfile
@@ -1,0 +1,72 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=xxx
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_WITHOUT="development:test" \
+    BUNDLE_DEPLOYMENT="1"
+
+# Update gems and bundler
+RUN gem update --system --no-document && \
+    gem install -N bundler
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential pkg-config
+
+# Install application gems
+COPY --link Gemfile Gemfile.lock ./
+RUN bundle install && \
+    bundle exec bootsnap precompile --gemfile && \
+    rm -rf ~/.bundle/ $BUNDLE_PATH/ruby/*/cache $BUNDLE_PATH/ruby/*/bundler/gems/*/.git
+
+# Copy application code
+COPY --link . .
+
+# Precompile bootsnap code for faster boot times
+RUN bundle exec bootsnap precompile app/ lib/
+
+# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+RUN SECRET_KEY_BASE=DUMMY ./bin/rails assets:precompile
+
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for deployment
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl default-mysql-client libsqlite3-0 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /rails /rails
+
+# Run and own only the runtime files as a non-root user for security
+ARG UID=xxx \
+    GID=1000
+RUN groupadd -f -g $GID rails && \
+    useradd -u $UID -g $GID rails --create-home --shell /bin/bash && \
+    chown -R rails:rails db log storage tmp
+USER rails:rails
+
+# Deployment options
+ENV RAILS_LOG_TO_STDOUT="1" \
+    RAILS_SERVE_STATIC_FILES="true"
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/test/results/trilogy/docker-compose.yml
+++ b/test/results/trilogy/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+services:
+  web:
+    build:
+      context: .
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-${UID:-1000}}
+    ports:
+      - "3000:3000"
+    environment:
+      - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+      - DATABASE_URL=trilogy://root:password@mysql-db/
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+
+  mysql-db:
+    image: mysql
+    command:
+      - --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+    volumes:
+      - ./tmp/db:/var/lib/mysql
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u root --password=password
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/test/test_trilogy.rb
+++ b/test/test_trilogy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class TestTrilogy < TestBase
+  @generate_options = "--compose"
+
+  def app_setup
+    system "bundle add trilogy"
+  end
+
+  def test_trilogy
+    check_dockerfile
+    check_compose
+  end
+end


### PR DESCRIPTION
Trilogy has been in production use for quite some time and will see official Rails support soon: https://github.com/rails/rails/pull/47880

This makes sure we detect the usage of trilogy and adapt the output accordingly. We also skip installing the libmysql-dev headers, since they're not needed with trilogy.

Note: This is a first shot and the more I think about it, the more it might make sense to have a separate `--trilogy` option, instead of having nested conditions. It will result in a bit more code, but I think it's more readable this way.

What do you think?