### PR TITLE
Require Ruby 2.6

### DIFF
--- a/dockerfile-rails.gemspec
+++ b/dockerfile-rails.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "*.md"]
 
   spec.add_dependency "rails"
+
+  spec.required_ruby_version = '>= 2.6.0'
 end

--- a/dockerfile-rails.gemspec
+++ b/dockerfile-rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails"
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = ">= 2.6.0"
 end

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -38,7 +38,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "variant" => "slim",
     "windows" => false,
     "yjit" => false,
-  }.then { |hash| Struct.new(*hash.keys.map(&:to_sym)).new(*hash.values) }
+  }.yield_self { |hash| Struct.new(*hash.keys.map(&:to_sym)).new(*hash.values) }
 
   OPTION_DEFAULTS = BASE_DEFAULTS.dup
 
@@ -319,7 +319,7 @@ private
     scope = (Class.new do
       def initialize(obj, locals)
         @_obj = obj
-        @_locals = locals.then do |hash|
+        @_locals = locals.yield_self do |hash|
           return nil if hash.empty?
           Struct.new(*hash.keys.map(&:to_sym)).new(*hash.values)
         end


### PR DESCRIPTION
I was trying to use this gem on Ruby 2.5 (sigh) and ran into an issue. It turns out that it calls `then` on a Hash, which was added in Ruby 2.6. I figured it would be helpful to document this explicitly, though hopefully there aren't a lot of people out there running 2.5.

https://til.hashrocket.com/posts/f4agttd8si-chaining-then-in-ruby-26