### PR TITLE
Improve nginx proxy headers

### DIFF
--- a/lib/generators/templates/_nginx.erb
+++ b/lib/generators/templates/_nginx.erb
@@ -27,8 +27,8 @@ server {
   }
 
   location @backend {
+    include proxy_params;
     proxy_pass http://localhost:3001;
-    proxy_set_header origin 'http://localhost:3000';
   }
 }
 EOF

--- a/test/results/nginx/Dockerfile
+++ b/test/results/nginx/Dockerfile
@@ -71,8 +71,8 @@ server {
   }
 
   location @backend {
+    include proxy_params;
     proxy_pass http://localhost:3001;
-    proxy_set_header origin 'http://localhost:3000';
   }
 }
 EOF


### PR DESCRIPTION
1. Include the default proxy pass options for nginx in order to pass a usable Host header to Rails.
2. Remove the forced Origin header since it causes problems like:

```
09:51:01 rails.1 | [5294cfff-b285-4779-8184-094c47432134] ActionController::InvalidAuthenticityToken (HTTP Origin header (http://localhost:3000) didn't match request.base_url (http://hello.local:3000)):
```

Before (when visiting http://hello.local:3000/):

```
HTTP_HOST: localhost:3001
HTTP_ORIGIN: http://localhost:3000
```

After:

```
HTTP_HOST: hello.local:3000
HTTP_X_REAL_IP: 172.17.0.1
HTTP_X_FORWARDED_FOR: 172.17.0.1
HTTP_X_FORWARDED_PROTO: http
```

Docker is fairly new to me, I may be missing a bigger point with the Origin header.