### PR TITLE
Using proxy_params was too heavy handed

### DIFF
--- a/lib/generators/templates/_nginx.erb
+++ b/lib/generators/templates/_nginx.erb
@@ -27,8 +27,8 @@ server {
   }
 
   location @backend {
-    include proxy_params;
     proxy_pass http://localhost:3001;
+    proxy_set_header Host $http_host;
   }
 }
 EOF

--- a/test/results/nginx/Dockerfile
+++ b/test/results/nginx/Dockerfile
@@ -71,8 +71,8 @@ server {
   }
 
   location @backend {
-    include proxy_params;
     proxy_pass http://localhost:3001;
+    proxy_set_header Host $http_host;
   }
 }
 EOF


### PR DESCRIPTION
The default nginx proxy_params directives clobber the LB upstream HTTP_X_FORWARDED_PROTO header by setting it to $scheme.

Instead, only set the Host header to overcome the implicit Host set by the proxy_pass directive, and rely on default behavior to pass on the remaining upstream headers from the LB.

Using $http_host rather than $host since the former is the client Host header and preserves the port number if present (tested to work both locally and behind LB).