### PR TITLE
Add Rollbar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ bin/rails generate dockerfile
 * `--nginx` - serve static files via [nginx](https://www.nginx.com/).  May require `--root` on some targets to access `/dev/stdout`
 * `--no-link` - don't add [--link](https://docs.docker.com/engine/reference/builder/#copy---link) to COPY statements.  Some tools (like at the moment, [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah)) don't yet support this feature.
 * `--no-lock` - don't add linux platforms, set `BUNDLE_DEPLOY`, or `--frozen-lockfile`.  May be needed at times to work around a [rubygems bug](https://github.com/rubygems/rubygems/issues/6082#issuecomment-1329756343).
-* `--sentry` -- install gems and a starter initializer for sentry
 * `--sudo` - install and configure sudo to enable `sudo -iu rails` access to full environment
+  #### Error Tracking & Alerting:
+  * `--rollbar` - install gem and a default initializer for Rollbar
+  * `--sentry` - install gems and a default initializer for Sentry
 
 ### Add a Database:
 

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -31,6 +31,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "procfile" => "",
     "redis" => false,
     "registry" => "",
+    "rollbar" => false,
     "root" => false,
     "sqlite3" => false,
     "sentry" => false,
@@ -171,7 +172,10 @@ class DockerfileGenerator < Rails::Generators::Base
     desc: "Install and configure sudo to enable running as rails with full environment"
 
   class_option :sentry, type: :boolean, default: OPTION_DEFAULTS.sentry,
-    desc: "Install gems and a starter initializer for sentry"
+    desc: "Install gems and a default initializer for Sentry"
+
+  class_option :rollbar, type: :boolean, default: OPTION_DEFAULTS.rollbar,
+    desc: "Install gem and a default initializer for Rollbar"
 
   class_option "migrate", type: :string, default: OPTION_DEFAULTS.migrate,
     desc: "custom migration/db:prepare script"
@@ -297,6 +301,10 @@ class DockerfileGenerator < Rails::Generators::Base
 
     if options.sentry? && (not File.exist?("config/initializers/sentry.rb"))
       template "sentry.rb.erb", "config/initializers/sentry.rb"
+    end
+
+    if options.rollbar? && (not File.exist?("config/initializers/rollbar.rb"))
+      template "rollbar.rb.erb", "config/initializers/rollbar.rb"
     end
 
     if @gemfile.include?("vite_ruby")
@@ -443,6 +451,10 @@ private
     if options.sentry?
       system "bundle add sentry-ruby --skip-install" unless @gemfile.include? "sentry-ruby"
       system "bundle add sentry-rails --skip-install" unless @gemfile.include? "sentry-rails"
+    end
+
+    if options.rollbar?
+      system "bundle add rollbar --skip-install" unless @gemfile.include? "rollbar"
     end
 
     # https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp/70500221#70500221

--- a/lib/generators/templates/rollbar.rb.erb
+++ b/lib/generators/templates/rollbar.rb.erb
@@ -1,0 +1,73 @@
+if ENV['ROLLBAR_ENV']
+  Rollbar.configure do |config|
+    # Without configuration, Rollbar is enabled in all environments.
+    # To disable in specific environments, set config.enabled=false.
+
+    config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+    # Here we'll disable in 'test':
+    if Rails.env.test?
+      config.enabled = false
+    end
+
+    # By default, Rollbar will try to call the `current_user` controller method
+    # to fetch the logged-in user object, and then call that object's `id`
+    # method to fetch this property. To customize:
+    # config.person_method = "my_current_user"
+    # config.person_id_method = "my_id"
+
+    # Additionally, you may specify the following:
+    # config.person_username_method = "username"
+    # config.person_email_method = "email"
+
+    # If you want to attach custom data to all exception and message reports,
+    # provide a lambda like the following. It should return a hash.
+    # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+    # Add exception class names to the exception_level_filters hash to
+    # change the level that exception is reported at. Note that if an exception
+    # has already been reported and logged the level will need to be changed
+    # via the rollbar interface.
+    # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+    # 'ignore' will cause the exception to not be reported at all.
+    # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+    #
+    # You can also specify a callable, which will be called with the exception instance.
+    # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+    # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+    # is not installed)
+    # config.use_async = true
+    # Supply your own async handler:
+    # config.async_handler = Proc.new { |payload|
+    #  Thread.new { Rollbar.process_from_async_handler(payload) }
+    # }
+
+    # Enable asynchronous reporting (using sucker_punch)
+    # config.use_sucker_punch
+
+    # Enable delayed reporting (using Sidekiq)
+    # config.use_sidekiq
+    # You can supply custom Sidekiq options:
+    # config.use_sidekiq 'queue' => 'default'
+
+    # If your application runs behind a proxy server, you can set proxy parameters here.
+    # If https_proxy is set in your environment, that will be used. Settings here have precedence.
+    # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
+    # are optional.
+    #
+    # config.proxy = {
+    #   host: 'http://some.proxy.server',
+    #   port: 80,
+    #   user: 'username_if_auth_required',
+    #   password: 'password_if_auth_required'
+    # }
+
+    # If you run your staging application instance in production environment then
+    # you'll want to override the environment reported by `Rails.env` with an
+    # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+    # setup for Heroku. See:
+    # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+    config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+  end
+end


### PR DESCRIPTION
### Purpose:
I have seen @rubys adding the support for Sentry a couple of weeks ago: https://github.com/fly-apps/dockerfile-rails/commit/76e7b22755ebfeb7c1f86f025f93b382fdcfe391. In this pull request I have added the support for Rollbar https://rollbar.com ; https://github.com/rollbar/rollbar-gem. Rollbar is a popular alternative to Sentry, both of the tools work in the similar way - offering Error / Exceptions / Performance tracking, monitoring, alerting & tracing. In the projects I'm working in we have been using the dockerfile-rails gem a lot lately (great tool! :wink:) and we also use both Sentry & Rollbar. It would be nice to have an alternative as a generator.

### Changes:
- updated README to be more readable, moved Sentry bulletpoint under the Error Tracking & Alerting section of Features
- added Rollbar generator to README
- added Rollbar generator to lib/generators/dockerfile_generator.rb
- added Rollbar initializer template to lib/generators/templates/rollbar.rb.erb
- set Rollbar initializer to work only if ENV['ROLLBAR_ENV'] is present

### Previews & test:
I have tested the generator on my local machine & on the new Rails app. Rollbar gem was properly added, installed. Initializer is working as well.
<img width="557" alt="Screenshot 2023-08-09 at 12 25 57" src="https://github.com/fly-apps/dockerfile-rails/assets/99652987/42979973-abd1-41d7-840e-83493fddbccc">

Preview of README after changes:
![Screenshot 2023-08-09 at 12 41 19](https://github.com/fly-apps/dockerfile-rails/assets/99652987/a6ad4826-1b1b-4374-9162-bc2148c6fb92)
_______________

Not sure if generators like this one are something that you would like to include in the gem, if no, feel free to close the PR. :relaxed: