### PR TITLE
Speed up node install from ~60s to ~5s

### DIFF
--- a/lib/generators/templates/_install_node.erb
+++ b/lib/generators/templates/_install_node.erb
@@ -13,7 +13,7 @@ ARG YARN_VERSION=<%= yarn_version %>
 <% end -%>
 <% if node_version -%>
 ENV PATH=/usr/local/node/bin:$PATH
-RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+RUN curl -sL "$(curl -s https://api.github.com/repos/nodenv/node-build/releases/latest | grep 'tarball_url' | cut -d\" -f4)" | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
 <% end -%>
 <% if yarn_version -%>


### PR DESCRIPTION
If you download the tarball of the master branch, it’s throttled to like 50kb/sec, and downloading the tarball takes 20-60 seconds. If you download the tarball of the latest tagged release, it does not seem to be throttled at all, and reduces the amount of time the "install node" step takes on my machine down to about 5 seconds total.