### PR TITLE
Avoids invalid byte sequence in UTF-8

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -849,7 +849,9 @@ private
 
   def binfile_fixups
     # binfiles may have OS specific paths to ruby.  Normalize them.
-    shebangs = Dir["bin/*"].map { |file| IO.read(file).lines.first }.join
+    shebangs = Dir["bin/*"].map do |file|
+      IO.read(file).lines.first.encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "")
+    end.join
     rubies = shebangs.scan(%r{#!/usr/bin/env (ruby.*)}).flatten.uniq
 
     binfixups = (rubies - %w(ruby)).map do |ruby|


### PR DESCRIPTION
This patch ensures that the code can handle input strings containing non-UTF-8 characters without causing the "invalid byte sequence in UTF-8 (ArgumentError)" exception when running a `scan`.

Output of the error before this patch:

```
/home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/dockerfile-rails-1.5.3/lib/generators/dockerfile_generator.rb:853:in `scan': invalid byte sequence in UTF-8 (ArgumentError)

    rubies = shebangs.scan(%r{#!/usr/bin/env (ruby.*)}).flatten.uniq
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/dockerfile-rails-1.5.3/lib/generators/dockerfile_generator.rb:853:in `binfile_fixups'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/dockerfile-rails-1.5.3/lib/generators/templates/Dockerfile.erb:133:in `template'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/3.2.0/erb.rb:429:in `eval'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/3.2.0/erb.rb:429:in `result'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/file_manipulation.rb:131:in `block in template'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:53:in `render'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:63:in `block (2 levels) in invoke!'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:63:in `open'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:63:in `block in invoke!'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/empty_directory.rb:117:in `invoke_with_conflict_check'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:60:in `invoke!'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions.rb:93:in `action'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/create_file.rb:25:in `create_file'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/actions/file_manipulation.rb:122:in `template'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/dockerfile-rails-1.5.3/lib/generators/dockerfile_generator.rb:275:in `generate_app'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:134:in `block in invoke_all'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:134:in `each'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:134:in `map'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:134:in `invoke_all'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/group.rb:232:in `dispatch'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.5/lib/rails/generators.rb:263:in `invoke'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.5/lib/rails/commands/generate/generate_command.rb:26:in `perform'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.5/lib/rails/command/base.rb:87:in `perform'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.5/lib/rails/command.rb:48:in `invoke'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.5/lib/rails/commands.rb:18:in `<main>'
	from <internal:/home/kinduff/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
	from <internal:/home/kinduff/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:38:in `require'
	from /home/kinduff/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
```