### PR TITLE
Gem.ruby_version compares against a Gem::Version object

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -501,7 +501,7 @@ private
     if options.ci? && options.lock? && @gemfile.include?("debug")
       # https://github.com/rails/rails/pull/47515
       # https://github.com/rubygems/rubygems/issues/6082#issuecomment-1329756343
-      gems += %w(irb reline) - @gemfile unless Gem.ruby_version >= "3.2.2"
+      gems += %w(irb reline) - @gemfile unless Gem.ruby_version >= Gem::Version.new("3.2.2")
     end
 
     gems.sort


### PR DESCRIPTION
Support to compare against a String wasn't added until RubyGems 3.4.19 (~1 yr ago).

https://github.com/rubygems/rubygems/commit/7e0dbb79f2c351532ae6c8cf12d5b39579dc4c54

Closes #58 