### PR TITLE
Do not install node if bun is present

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -415,7 +415,8 @@ private
 
   def using_node?
     return @using_node if @using_node != nil
-    @using_node = File.exist? "package.json"
+    return if using_bun?
+    @using_node = File.exist?("package.json")
   end
 
   def using_bun?
@@ -455,7 +456,7 @@ private
   end
 
   def parallel?
-    using_node? && options.parallel
+    (using_node? || using_bun?) && options.parallel
   end
 
   def has_mysql_gem?
@@ -645,6 +646,10 @@ private
       else
         packages << "python"
       end
+    end
+
+    if using_bun?
+      packages += %w(curl unzip)
     end
 
     if options.alpine?

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -623,7 +623,6 @@ private
 
       unless using_execjs? || using_puppeteer?
         packages << "curl"
-        packages << "unzip" if using_bun?
       end
 
       # module build process depends on Python, and debian changed

--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -143,7 +143,7 @@ COPY --from=node /usr/local/node /usr/local/node
 ENV PATH=/usr/local/node/bin:$PATH
 <% end -%>
 
-<% elsif using_node? -%>
+<% elsif using_node? || using_bun? -%>
 <%= render partial: 'npm_install', locals: {sources: Dir[*%w(.npmrc .yarnrc package.json package-lock.json yarn.lock bun.lockb)]} %>
 
 <% end -%>

--- a/test/results/bun/Dockerfile
+++ b/test/results/bun/Dockerfile
@@ -21,9 +21,9 @@ RUN gem update --system --no-document && \
 # Throw-away build stage to reduce size of final image
 FROM base as build
 
-# Install packages needed to build gems and node modules
+# Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl node-gyp pkg-config python-is-python3 unzip
+    apt-get install --no-install-recommends -y build-essential curl pkg-config unzip
 
 # Install Bun
 ARG BUN_VERSION=xxx


### PR DESCRIPTION
If one uses Bun, the generator doesn't consider Node unnecessary and will add Node (and generate `.node-version` file) into the Dockerfile. As per the issue linked in #70, this can cause issues (e.g. assets won't precompile).

Fixes #70 

