### PR TITLE
Add correct mapping for Alpine's jemalloc

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -65,6 +65,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "libmagickwand-dev" => "imagemagick-libs",
     "libsqlite3-0" => "sqlite-dev",
     "libtiff-dev" => "tiff-dev",
+    "libjemalloc2" => "jemalloc",
     "libvips" => "vips-dev",
     "node-gyp" => "gyp",
     "pkg-config" => "pkgconfig",


### PR DESCRIPTION
I found this missing mapping for Alpine: `libjemalloc2` is used in Debian-based distros, while [Alpine](https://pkgs.alpinelinux.org/packages?name=jemalloc) simply uses `jemalloc`. 

I'm unsure if this needs a dedicated test, update `test_alpine.rb` to include jemalloc option, or if this is sufficient. Happy to update the PR with more tests