### PR TITLE
Continue to support Ruby < 3

### DIFF
--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -31,7 +31,7 @@ ARG <%= base_args.map {|key, value| "#{key}=#{value.inspect}"}.join(" \\\n    ")
 ENV <%= base_env.join(" \\\n    ") %>
 
 # Update gems and bundler
-RUN gem update --system --no-document && \
+RUN gem update --system <% if RUBY_VERSION.start_with? '2' %><3.4.22 <% end %>--no-document && \
     gem install -N <%= base_gems.join(" ") %>
 
 <% unless base_packages.empty? -%>


### PR DESCRIPTION
Rubygems has dropped support for Ruby 2.6 and 2.7 in version 3.5.0. https://github.com/rubygems/rubygems/releases/tag/v3.5.0