### PR TITLE
Update litefs to 0.5

### DIFF
--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -181,7 +181,7 @@ FROM base
 <% end -%>
 <% if using_litefs? -%>
 # Install, configure litefs
-COPY --from=flyio/litefs:0.4.0 /usr/local/bin/litefs /usr/local/bin/litefs
+COPY --from=flyio/litefs:0.5 /usr/local/bin/litefs /usr/local/bin/litefs
 COPY<% if options.link? %> --link<% end %> config/litefs.yml /etc/litefs.yml
 
 <% end -%>

--- a/test/results/litefs/Dockerfile
+++ b/test/results/litefs/Dockerfile
@@ -45,7 +45,7 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 FROM base
 
 # Install, configure litefs
-COPY --from=flyio/litefs:0.4.0 /usr/local/bin/litefs /usr/local/bin/litefs
+COPY --from=flyio/litefs:0.5 /usr/local/bin/litefs /usr/local/bin/litefs
 COPY --link config/litefs.yml /etc/litefs.yml
 
 # Install packages needed for deployment


### PR DESCRIPTION
Updates litefs to 0.5 to support litefs cloud.

Not sure if you'd prefer locking to a specific version, but this seemed safe enough for a generator.