### PR TITLE
Do not try to get node version unless node is installed

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -1034,7 +1034,7 @@ private
   end
 
   def node_version
-    return unless using_node?
+    return unless using_node? || using_execjs?
 
     version = nil
 

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -1034,6 +1034,8 @@ private
   end
 
   def node_version
+    return unless using_node?
+
     version = nil
 
     if File.exist? ".node-version"


### PR DESCRIPTION
I currently have Bun installed and just this morning, uninstalled Node. After that, I noticed that my Dockerfile keeps re-adding `nodejs` and `npm`. Debugging a little bit, the `node_version` method has a rescue that defaults to `"lts"` in case there's an error, and that's what happens when node command is not found. I figure that it should be safe to just not try to find a version if we are not using node anyways