### PR TITLE
If private gemserver is defined, include it in the queue compose defition

### DIFF
--- a/lib/generators/templates/docker-compose.yml.erb
+++ b/lib/generators/templates/docker-compose.yml.erb
@@ -99,6 +99,10 @@ services:
 <% else -%>
     command: bundle exec rake solid_queue:start
 <% end -%>
+<% if private_gemserver_env_variable_name -%>
+    secrets:
+      - gemserver_credentials
+<% end -%>
     environment:
       - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
       - REDIS_URL=redis://redis-db:6379


### PR DESCRIPTION
When building the images, if the dockerfile has been set up with a private gemserver, the queue image (sidekiq or solid_queue) will fail to build, since the private gemserver secret is not defined.

By including the `secrets:` in the appropriate section of the docker-compose.yml, it'll build.