### PR TITLE
Correctly mount secrets

### DIFF
--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -90,7 +90,7 @@ COPY<% if options.link? %> --link<% end %> Gemfile Gemfile.lock <% if references
 <% if options.cache? -%>
 RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
 <% if private_gemserver_env_variable_name -%>
-    --mount=type=secret,id=gemserver_credentials,dst=/kaniko/gemserver_credentials \
+    --mount=type=secret,id=gemserver_credentials,target=/kaniko/gemserver_credentials \
     <%= private_gemserver_env_variable_name %>="$(cat /kaniko/gemserver_credentials)" && \
     export <%= private_gemserver_env_variable_name %> && \
 <% end -%>
@@ -107,7 +107,7 @@ RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
 
 <% else -%>
 <% if private_gemserver_env_variable_name -%>
-RUN --mount=type=secret,id=gemserver_credentials,dst=/kaniko/gemserver_credentials \
+RUN --mount=type=secret,id=gemserver_credentials,target=/kaniko/gemserver_credentials \
     <%= private_gemserver_env_variable_name %>="$(cat /kaniko/gemserver_credentials)" && \
     export <%= private_gemserver_env_variable_name %> && \
     bundle install<% if depend_on_bootsnap? && options.precompile != "defer" -%> && \

--- a/test/results/private_gemserver/Dockerfile
+++ b/test/results/private_gemserver/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -qq && \
 
 # Install application gems
 COPY --link Gemfile Gemfile.lock ./
-RUN --mount=type=secret,id=gemserver_credentials,dst=/kaniko/gemserver_credentials \
+RUN --mount=type=secret,id=gemserver_credentials,target=/kaniko/gemserver_credentials \
     BUNDLE_GEMS__EXAMPLE__COM="$(cat /kaniko/gemserver_credentials)" && \
     export BUNDLE_GEMS__EXAMPLE__COM && \
     bundle install && \

--- a/test/results/private_gemserver_with_cache/Dockerfile
+++ b/test/results/private_gemserver_with_cache/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
 # Install application gems
 COPY --link Gemfile Gemfile.lock ./
 RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
-    --mount=type=secret,id=gemserver_credentials,dst=/kaniko/gemserver_credentials \
+    --mount=type=secret,id=gemserver_credentials,target=/kaniko/gemserver_credentials \
     BUNDLE_GEMS__EXAMPLE__COM="$(cat /kaniko/gemserver_credentials)" && \
     export BUNDLE_GEMS__EXAMPLE__COM && \
     bundle config set app_config .bundle && \


### PR DESCRIPTION
According to the [Dockerfile reference for RUN --mount=type=secret](https://docs.docker.com/reference/dockerfile/#run---mounttypesecret), the parameter specifying the destination is supposed to be `target`, not `dst`