### PR TITLE
Add an advanced option to skip any Gemfile updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ There may be times where feature detection plus flags just aren't enough.  As an
 
 * `--instructions=path` - a dockerfile fragment to be inserted into the final document.
 * `--migration=cmd` - a replacement (generally a script) for `db:prepare`/`db:migrate`.
+* `--no-gemfile-updates` - do not modify my gemfile.
 * `--procfile=path` - a [Procfile](https://github.com/ddollar/foreman#foreman) to use in place of launching Rails directly.
 
 Like with environment variables, packages, and build args, `--instructions` can be tailored to a specific build phase by adding `-base`, `-build`, or `-deploy` after the flag name, with the default being `-deploy`.

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -14,6 +14,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "ci" => false,
     "compose" => false,
     "fullstaq" => false,
+    "gemfile-updates" => true,
     "jemalloc" => false,
     "label" => {},
     "link" => true,
@@ -218,6 +219,9 @@ class DockerfileGenerator < Rails::Generators::Base
 
   class_option "private-gemserver-domain", type: :string, default: OPTION_DEFAULTS["private-gemserver-domain"],
     desc: "domain name of a private gemserver used when installing application gems"
+
+  class_option "gemfile-updates", type: :boolean, default: OPTION_DEFAULTS["gemfile-updates"],
+    desc: "include gemfile updates"
 
 
   class_option "add-base", type: :array, default: [],
@@ -510,6 +514,8 @@ private
   end
 
   def install_gems
+    return unless options["gemfile-updates"]
+
     ENV["BUNDLE_IGNORE_MESSAGES"] = "1"
 
     gemfile = IO.read("Gemfile")


### PR DESCRIPTION
## Motivation

Our standard dockerfile-rails update flow is to bump the gem, run `rails generate dockerfile`, have it overwrite everything, use the git diff to undo anything we don't want. This is getting really close to not requiring undoing anything, with the Gemfile being a notable exception. For us, we know exactly what we do and don't want in our Gemfile, but we don't have the same level of confidence with the docker interactions, which is what we use this gem for. Particularly annoying at the moment is the insistence that Redis is the only way to run ActionCable.

Generally, I would argue that interacting with the Gemfile at all is beyond the scope of what dockerfile-rails should do, possibly with the exception of checking lock platforms, but I suspect that is likely an uphill battle.

## Proposed solution

Add an option to skip modifying the Gemfile. I added the option description to the Readme under the advanced section because it's skipping a significant number of touch points.

I went looking for a place to add tests, but it doesn't appear there are currently tests for any of the Gemfile interactions.