### PR TITLE
change --migration to --migrate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Args and environment variables can be tailored to a specific build phase by addi
 There may be times where feature detection plus flags just aren't enough.  As an example, you may wish to configure and run multiple processes.
 
 * `--instructions=path` - a dockerfile fragment to be inserted into the final document.
-* `--migration=cmd` - a replacement (generally a script) for `db:prepare`/`db:migrate`.
+* `--migrate=cmd` - a replacement (generally a script) for `db:prepare`/`db:migrate`.
 * `--procfile=path` - a [Procfile](https://github.com/ddollar/foreman#foreman) to use in place of launching Rails directly.
 
 Like with environment variables, packages, and build args, `--instructions` can be tailored to a specific build phase by adding `-base`, `-build`, or `-deploy` after the flag name, with the default being `-deploy`.


### PR DESCRIPTION
Hey! Tiny correction to readme cause `--migration` does not work