### PR TITLE
Add option to compile all gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ different contents.  If both are specified, `--force` takes precedence.
 * `--no-link` - don't add [--link](https://docs.docker.com/engine/reference/builder/#copy---link) to COPY statements.  Some tools (like at the moment, [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah)) don't yet support this feature.
 * `--no-lock` - don't add linux platforms, set `BUNDLE_DEPLOY`, or `--frozen-lockfile`.  May be needed at times to work around a [rubygems bug](https://github.com/rubygems/rubygems/issues/6082#issuecomment-1329756343).
 * `--sudo` - install and configure sudo to enable `sudo -iu rails` access to full environment
+* `--no-precompiled-gems` - compile all gems instead of using precompiled versions
 
 #### Error Tracking & Alerting:
 * `--rollbar` - install gem and a default initializer for [Rollbar](https://rollbar.com/#)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ different contents.  If both are specified, `--force` takes precedence.
 * `--no-link` - don't add [--link](https://docs.docker.com/engine/reference/builder/#copy---link) to COPY statements.  Some tools (like at the moment, [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah)) don't yet support this feature.
 * `--no-lock` - don't add linux platforms, set `BUNDLE_DEPLOY`, or `--frozen-lockfile`.  May be needed at times to work around a [rubygems bug](https://github.com/rubygems/rubygems/issues/6082#issuecomment-1329756343).
 * `--sudo` - install and configure sudo to enable `sudo -iu rails` access to full environment
-* `--no-precompiled-gems` - compile all gems instead of using precompiled versions
 
 #### Error Tracking & Alerting:
 * `--rollbar` - install gem and a default initializer for [Rollbar](https://rollbar.com/#)
@@ -98,6 +97,7 @@ Args and environment variables can be tailored to a specific build phase by addi
 * `--root` - run application as root
 * `--windows` - make Dockerfile work for Windows users that may have set `git config --global core.autocrlf true`
 * `--private-gemserver-domain=gems.example.com` - set the domain name of your private gemserver.  This is used to tell bundler for what domain to use the credentials of a private gemserver provided via a docker secret
+* `--no-precompiled-gems` - compile all gems instead of using precompiled versions
 
 ### Advanced Customization:
 

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -29,6 +29,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "platform" => nil,
     "postgresql" => false,
     "precompile" => nil,
+    "precompiled-gems" => true,
     "prepare" => true,
     "private-gemserver-domain" => nil,
     "procfile" => "",
@@ -123,6 +124,9 @@ class DockerfileGenerator < Rails::Generators::Base
 
   class_option :precompile, type: :string, default: OPTION_DEFAULTS.precompile,
     desc: 'if set to "defer", assets:precompile will be done at deploy time'
+
+  class_option "precompiled-gems", type: :boolean, default: OPTION_DEFAULTS["precompiled-gems"],
+    desc: "use precompiled gems"
 
   class_option "bin-cd", type: :boolean, default: OPTION_DEFAULTS["bin-cd"],
     desc: "modify binstubs to set working directory"
@@ -222,7 +226,6 @@ class DockerfileGenerator < Rails::Generators::Base
 
   class_option "gemfile-updates", type: :boolean, default: OPTION_DEFAULTS["gemfile-updates"],
     desc: "include gemfile updates"
-
 
   class_option "add-base", type: :array, default: [],
     desc: "additional packages to install for both build and deploy"

--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -113,7 +113,7 @@ RUN --mount=type=secret,id=gemserver_credentials,target=/kaniko/gemserver_creden
     bundle install<% if depend_on_bootsnap? && options.precompile != "defer" -%> && \
     bundle exec bootsnap precompile --gemfile<% end %> && \
 <% else -%>
-RUN bundle install<% if depend_on_bootsnap? && options.precompile != "defer" -%> && \
+RUN <% if options["precompiled-gems"] != true %>bundle config set force_ruby_platform true && \<%= "\n    " %><% end %>bundle install<% if depend_on_bootsnap? && options.precompile != "defer" -%> && \
     bundle exec bootsnap precompile --gemfile<% end %> && \
 <% end -%>
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git

--- a/test/results/no_precompiled_gems/Dockerfile
+++ b/test/results/no_precompiled_gems/Dockerfile
@@ -1,0 +1,69 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=xxx
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development:test" \
+    RAILS_ENV="production"
+
+# Update gems and bundler
+RUN gem update --system --no-document && \
+    gem install -N bundler
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential pkg-config
+
+# Install application gems
+COPY --link Gemfile Gemfile.lock ./
+RUN bundle config set force_ruby_platform true && \
+    bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+
+# Copy application code
+COPY --link . .
+
+# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for deployment
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libsqlite3-0 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /rails /rails
+
+# Run and own only the runtime files as a non-root user for security
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    mkdir /data && \
+    chown -R 1000:1000 db log storage tmp /data
+USER 1000:1000
+
+# Deployment options
+ENV DATABASE_URL="sqlite3:///data/production.sqlite3"
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+VOLUME /data
+CMD ["./bin/rails", "server"]

--- a/test/test_no_precompiled_gems.rb
+++ b/test/test_no_precompiled_gems.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class TestNoPrecompiledGems < TestBase
+  @rails_options = "--minimal"
+  @generate_options = "--no-precompiled-gems"
+
+  def test_ci
+    check_dockerfile
+  end
+end


### PR DESCRIPTION
The pre-compiled version of nokogiri for ARM requires a newer version of glibc than the ruby docker images come with. This can be worked around by not using the pre-compiled versions and instead compiling all gems.

This can be done with the bundle configuration `bundle config set force_ruby_platform true`