### PR TITLE
Document `--registry` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ There may be times where feature detection plus flags just aren't enough.  As an
 * `--migrate=cmd` - a replacement (generally a script) for `db:prepare`/`db:migrate`.
 * `--no-gemfile-updates` - do not modify my gemfile.
 * `--procfile=path` - a [Procfile](https://github.com/ddollar/foreman#foreman) to use in place of launching Rails directly.
+* `--registry=another.docker.registry.com` - use a different registry for sourcing Docker images (e.g. public.ecr.aws).
 
 Like with environment variables, packages, and build args, `--instructions` can be tailored to a specific build phase by adding `-base`, `-build`, or `-deploy` after the flag name, with the default being `-deploy`.
 


### PR DESCRIPTION
The `--registry` option is available from the command line, but isn't documented in the README. I was about to open an issue asking about it before I found `options.registry` in the `Dockerfile.erb` template.