### PR TITLE
Detect Bun with new test-based lockfile

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -511,7 +511,7 @@ private
 
   def using_bun?
     return @using_bun if @using_bun != nil
-    @using_bun = File.exist?("bun.config.js") || File.exist?("bun.lockb")
+    @using_bun = File.exist?("bun.config.js") || File.exist?("bun.lockb") || File.exist?("bun.lock")
   end
 
   def references_ruby_version_file?


### PR DESCRIPTION
In version 1.1.39, [Bun added a new text-based lockfile (`bun.lock`)](1) which will become the standard in version 1.2. The Bun check should account for this as well as the existing `bun.lockb`.

[1]: https://bun.sh/blog/bun-v1.1.39#bun-lock-is-bun-s-new-text-based-lockfile