### PR TITLE
Copy whatever file is defined as Ruby version on Gemfile

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -515,7 +515,12 @@ private
   end
 
   def references_ruby_version_file?
-    @references_ruby_version_file ||= IO.read("Gemfile").include?(".ruby-version")
+    @references_ruby_version_file ||= ruby_version_file.present?
+  end
+
+  def ruby_version_file
+    match = IO.read("Gemfile").match(/ruby file: ["'](.*)["']/)
+    match ? match[1] : nil
   end
 
   def using_redis?

--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -9,7 +9,7 @@
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 <% end -%>
 
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
+# Make sure RUBY_VERSION matches the Ruby version in <%= ruby_version_file || '.ruby-version' %>
 ARG RUBY_VERSION=<%= RUBY_VERSION %>
 <% if api_client_dir -%>
 <%= render partial: 'node_client' %>
@@ -95,7 +95,7 @@ ENV <%= build_env.join(" \\\n    ") %>
 
 <% end -%>
 # Install application gems
-COPY<% if options.link? %> --link<% end %> Gemfile Gemfile.lock <% if references_ruby_version_file? %>.ruby-version <% end %>./
+COPY<% if options.link? %> --link<% end %> Gemfile Gemfile.lock <% if references_ruby_version_file? %><%= ruby_version_file %> <% end %>./
 <% if @netpopbug && Rails.env != "test" -%>
 RUN sed -i "/net-pop (0.1.2)/a\      net-protocol" Gemfile.lock
 <% end -%>


### PR DESCRIPTION
A couple of weeks ago I added support for [Mise as a version manager on Bundler](https://github.com/rubygems/rubygems/pull/8356). This PR updates the template so we copy whatever file user has defined as version manager, not only `.ruby-version`