### PR TITLE
Clean up bin/docker-entrypoint server check when running litestream

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -1166,7 +1166,7 @@ private
 
       thrust = command.index("./bin/thrust")
       thrust = command.index("litestream:run") if thrust.nil?
-      command = command[thrust+1...] unless thrust.nil?
+      command = command[thrust + 1...] unless thrust.nil?
 
       command
     end

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -1164,11 +1164,11 @@ private
     else
       command = Shellwords.split(procfile.values.first)
 
-      if command.first == "./bin/thrust"
-        command[1..]
-      else
-        command
-      end
+      thrust = command.index("./bin/thrust")
+      thrust = command.index("litestream:run") if thrust.nil?
+      command = command[thrust+1...] unless thrust.nil?
+
+      command
     end
   end
 

--- a/test/results/litestream/docker-entrypoint
+++ b/test/results/litestream/docker-entrypoint
@@ -7,7 +7,7 @@ if [ -z "${LD_PRELOAD+x}" ]; then
 fi
 
 # If running the rails server then create or migrate existing database
-if [ "${@: -5:1}" == "./bin/rake" ] && [ "${@: -4:1}" == litestream:run ] && [ "${@: -3:1}" == "./bin/thrust" ] && [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 


### PR DESCRIPTION
Remove what launches the sever (thrust, litestream) from the check to see if we are running the server.  That makes the check more resilient to environment changes (example: not running thruster on fly.io).

See: https://community.fly.io/t/automatic-sqlite3-backups-for-rails-applications-using-litestream-and-tigris/23356/6?u=rubys