### PR TITLE
Install only production dependencies using Bun

### DIFF
--- a/lib/generators/templates/_npm_install.erb
+++ b/lib/generators/templates/_npm_install.erb
@@ -5,7 +5,7 @@ COPY<% if options.link? %> --link<% end %> .yarn/releases/* .yarn/releases/
 <% end -%>
 <% if using_bun? -%>
 RUN <% if options.cache? %>--mount=type=cache,id=bld-bun-cache,target=/root/.bun \
-    <% end %>bun install<% if options.lock? %> --frozen-lockfile<% end %>
+    <% end %>bun install<% if options.lock? %> --frozen-lockfile<% end %> --production
 <% elsif sources.join.include? 'yarn' -%>
 RUN <% if options.cache? %>--mount=type=cache,id=bld-yarn-cache,target=/root/.yarn \
     YARN_CACHE_FOLDER=/root/.yarn <% end %>yarn install<% if options.lock? %> --<% if yarn_version < '2' -%>frozen-lockfile<% else %>immutable<% end %><% end %>

--- a/test/results/bun/Dockerfile
+++ b/test/results/bun/Dockerfile
@@ -52,7 +52,7 @@ RUN bundle install && \
 
 # Install node modules
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --production
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
This could be extended to the other major JS providers too, but that
might be out of scope for this.
