### PR TITLE
Use nproc command to automatically scale to number of cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ different contents.  If both are specified, `--force` takes precedence.
 
 * `--cache` - use build caching to speed up builds
 * `--parallel` - use multi-stage builds to install gems and node modules in parallel
-* `--nproc n` - run bundle install in parallel
+* `--nproc` - run bundle install in parallel
 
 ### Add/remove a Feature:
 

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -27,7 +27,7 @@ class DockerfileGenerator < Rails::Generators::Base
     "mysql" => false,
     "nginx" => false,
     "parallel" => false,
-    "nproc" => 1,
+    "nproc" => false,
     "passenger" => false,
     "platform" => nil,
     "postgresql" => false,
@@ -149,7 +149,7 @@ class DockerfileGenerator < Rails::Generators::Base
   class_option :parallel, type: :boolean, default: OPTION_DEFAULTS.parallel,
     desc: "use build stages to install gems and node modules in parallel"
 
-  class_option :nproc, type: :numeric, default: OPTION_DEFAULTS.nproc,
+  class_option :nproc, type: :boolean, default: OPTION_DEFAULTS.nproc,
     desc: "run bundle install in parallel"
 
   class_option :swap, type: :string, default: OPTION_DEFAULTS.swap,

--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -96,8 +96,8 @@ ENV <%= build_env.join(" \\\n    ") %>
 <% end -%>
 # Install application gems
 COPY<% if options.link? %> --link<% end %> Gemfile Gemfile.lock <% if references_ruby_version_file? %><%= ruby_version_file %> <% end %>./
-<% if options.nproc > 1 -%>
-ENV MAKE="make -j<%= options.nproc %>"
+<% if options.nproc -%>
+ENV MAKE="make -j$(nproc)"
 <% end -%>
 <% if @netpopbug && Rails.env != "test" -%>
 RUN sed -i "/net-pop (0.1.2)/a\      net-protocol" Gemfile.lock


### PR DESCRIPTION
This PR changes the `nproc` option to be a boolean instead of a numeric. When the `nproc` option is set to `true`, the following line is added to the Dockerfile:
```Dockerfile
ENV MAKE="make -j$(nproc)"
```

which will cause the `make` command to automatically scale based on the number of CPU cores returned by the [`nproc`](https://man7.org/linux/man-pages/man1/nproc.1.html) command. `nproc` is part of GNU Core Utilities and should always be available.

This is a fairly common approach, e.g. https://github.com/search?q=path%3ADockerfile+%22ENV+MAKE%3D%5C%22make+-j%24%28nproc%29%5C%22%22&type=code